### PR TITLE
test: Fix missing tokio test macro dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ anyhow = "1.0.71"
 diesel_ltree = "0.3.0"
 typed-builder = "0.10.0"
 serial_test = "0.9.0"
-tokio = "1.28.2"
+tokio = { version = "1.28.2", features = ["macros"] }
 sha2 = "0.10.6"
 regex = "1.8.4"
 once_cell = "1.18.0"


### PR DESCRIPTION
The tests make use of the `#[tokio::test]` macro, but the tokio dependency default feature does not include them. Running cargo test fails.

By including the `macros` feature on the tokio dependency, cargo test will work.

---

cargo test fails with

```
error[E0433]: failed to resolve: could not find `test` in `tokio`
   --> src\scheduled_tasks.rs:295:12
    |
295 |   #[tokio::test]
    |            ^^^^ could not find `test` in `tokio`
```

---

Failing build proof: https://github.com/Kissaki/lemmy/actions/runs/5365082553/jobs/9733667926#step:4:430